### PR TITLE
YAML.safe_load

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -104,7 +104,7 @@ module Einhorn
   def self.load_yaml(raw)
     cooked_good = YAML.load(raw)
     options = {aliases: false}
-    options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION > "2.5"
+    options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION >= "2.6.0"
     # cooked_bad = YAML.safe_load(raw, options)
     # pp(bad: cooked_bad, good: cooked_good)
     cooked_good

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -101,8 +101,15 @@ module Einhorn
     end
   end
 
+  def self.load_yaml(raw)
+    cooked_good = YAML.load(raw)
+    # cooked_bad = YAML.safe_load(raw, permitted_classes: [Symbol, Set], aliases: false)
+    # pp(bad: cooked_bad, good: cooked_good)
+    cooked_good
+  end
+
   def self.restore_state(state)
-    parsed = YAML.load(state)
+    parsed = load_yaml(state)
     updated_state, message = update_state(Einhorn::State, "einhorn", parsed[:state])
     Einhorn::State.state = updated_state
     Einhorn::Event.restore_persistent_descriptors(parsed[:persistent_descriptors])

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -102,12 +102,13 @@ module Einhorn
   end
 
   def self.load_yaml(raw)
-    cooked_good = YAML.load(raw)
-    options = {aliases: false}
-    options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION >= "2.6.0"
-    # cooked_bad = YAML.safe_load(raw, options)
-    # pp(bad: cooked_bad, good: cooked_good)
-    cooked_good
+    if RUBY_VERSION >= "2.6.0"
+      options = {aliases: false, permitted_classes: [Symbol, Set]}
+      # YAML.safe_load(raw, options)
+      YAML.load(raw)
+    else
+      YAML.load(raw)
+    end
   end
 
   def self.restore_state(state)

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -104,8 +104,8 @@ module Einhorn
   def self.load_yaml(raw)
     if RUBY_VERSION >= "2.6.0"
       options = {aliases: false, permitted_classes: [Symbol, Set]}
-      # YAML.safe_load(raw, **options)
-      YAML.load(raw)
+      YAML.safe_load(raw, **options)
+      # YAML.load(raw)
     else
       YAML.load(raw)
     end

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -103,7 +103,9 @@ module Einhorn
 
   def self.load_yaml(raw)
     cooked_good = YAML.load(raw)
-    # cooked_bad = YAML.safe_load(raw, permitted_classes: [Symbol, Set], aliases: false)
+    options = {aliases: false}
+    options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION > "2.5"
+    # cooked_bad = YAML.safe_load(raw, options)
     # pp(bad: cooked_bad, good: cooked_good)
     cooked_good
   end

--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -104,7 +104,7 @@ module Einhorn
   def self.load_yaml(raw)
     if RUBY_VERSION >= "2.6.0"
       options = {aliases: false, permitted_classes: [Symbol, Set]}
-      # YAML.safe_load(raw, options)
+      # YAML.safe_load(raw, **options)
       YAML.load(raw)
     else
       YAML.load(raw)

--- a/lib/einhorn/client.rb
+++ b/lib/einhorn/client.rb
@@ -27,7 +27,9 @@ module Einhorn
       def self.deserialize_message(line)
         serialized = line.gsub(/%(25|0A)/, "%25" => "%", "%0A" => "\n")
         # YAML.load(serialized)
-        YAML.safe_load(serialized, permitted_classes: [Symbol, Set])
+        options = {}
+        options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION > "2.5"
+        YAML.safe_load(serialized, options)
       end
     end
 

--- a/lib/einhorn/client.rb
+++ b/lib/einhorn/client.rb
@@ -29,7 +29,7 @@ module Einhorn
         # YAML.load(serialized)
         if RUBY_VERSION >= "2.6.0"
           options = {aliases: false, permitted_classes: [Symbol, Set]}
-          YAML.safe_load(serialized, options)
+          YAML.safe_load(serialized, **options)
           # YAML.load(serialized)
         else
           YAML.load(serialized)

--- a/lib/einhorn/client.rb
+++ b/lib/einhorn/client.rb
@@ -28,7 +28,7 @@ module Einhorn
         serialized = line.gsub(/%(25|0A)/, "%25" => "%", "%0A" => "\n")
         # YAML.load(serialized)
         options = {}
-        options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION > "2.5"
+        options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION >= "2.6.0"
         YAML.safe_load(serialized, options)
       end
     end

--- a/lib/einhorn/client.rb
+++ b/lib/einhorn/client.rb
@@ -27,9 +27,13 @@ module Einhorn
       def self.deserialize_message(line)
         serialized = line.gsub(/%(25|0A)/, "%25" => "%", "%0A" => "\n")
         # YAML.load(serialized)
-        options = {}
-        options[:permitted_classes] = [Symbol, Set] if RUBY_VERSION >= "2.6.0"
-        YAML.safe_load(serialized, options)
+        if RUBY_VERSION >= "2.6.0"
+          options = {aliases: false, permitted_classes: [Symbol, Set]}
+          YAML.safe_load(serialized, options)
+          # YAML.load(serialized)
+        else
+          YAML.load(serialized)
+        end
       end
     end
 

--- a/lib/einhorn/client.rb
+++ b/lib/einhorn/client.rb
@@ -26,7 +26,8 @@ module Einhorn
 
       def self.deserialize_message(line)
         serialized = line.gsub(/%(25|0A)/, "%25" => "%", "%0A" => "\n")
-        YAML.load(serialized)
+        # YAML.load(serialized)
+        YAML.safe_load(serialized, permitted_classes: [Symbol, Set])
       end
     end
 

--- a/test/integration/_lib/helpers/einhorn_helpers.rb
+++ b/test/integration/_lib/helpers/einhorn_helpers.rb
@@ -106,7 +106,7 @@ module Helpers
 
     def get_state(client)
       client.send_command("command" => "state")
-      YAML.load(client.receive_message["message"])[:state]
+      Einhorn.load_yaml(client.receive_message["message"])[:state]
     end
 
     def wait_for_open_port

--- a/test/integration/_lib/helpers/einhorn_helpers.rb
+++ b/test/integration/_lib/helpers/einhorn_helpers.rb
@@ -49,12 +49,12 @@ module Helpers
         raise
       ensure
         unless (status = process.poll) && status.exited?
-          10.times do
+          100.times do
             status = process.poll
             if status && status.exited?
               break
             end
-            sleep(1)
+            sleep(0.1)
           end
           unless status && status.exited?
             warn "Could not get Einhorn to quit within 10 seconds, killing it forcefully..."
@@ -71,8 +71,8 @@ module Helpers
       Subprocess.check_call(%W[bundle exec #{File.expand_path("bin/einhornsh")}] + commandline,
         {
           stdin: "/dev/null",
-          stdout: "/dev/null",
-          stderr: "/dev/null"
+          stdout: $stdout,
+          stderr: $stderr,
         }.merge(options))
     end
 

--- a/test/integration/upgrading.rb
+++ b/test/integration/upgrading.rb
@@ -74,7 +74,7 @@ class UpgradeTests < EinhornIntegrationTestCase
           client.send_command("command" => "state")
           resp = client.receive_message
 
-          state = YAML.load(resp["message"])
+          state = Einhorn.load_yaml(resp["message"])
           assert_equal(1, state[:state][:children].count)
 
           child = state[:state][:children].first.last

--- a/test/unit/einhorn/command/interface.rb
+++ b/test/unit/einhorn/command/interface.rb
@@ -11,7 +11,7 @@ class InterfaceTest < EinhornTestCase
       conn.expects(:write).once.with do |message|
         # Remove trailing newline
         message = message[0...-1]
-        parsed = YAML.load(CGI.unescape(message))
+        parsed = Einhorn.load_yaml(CGI.unescape(message))
         parsed["message"] =~ /Welcome, gdb/
       end
       request = {


### PR DESCRIPTION
Use `YAML.safe_load` in order to work with Ruby 3.1+.

Fixes #102 