### PR TITLE
Handle Psych 4 safe_load

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -6,6 +6,7 @@ require "socket"
 require "tmpdir"
 require "yaml"
 require "shellwords"
+require "einhorn/safe_yaml"
 
 module Einhorn
   module AbstractState
@@ -102,7 +103,7 @@ module Einhorn
   end
 
   def self.restore_state(state)
-    parsed = YAML.load(state)
+    parsed = SafeYAML.load(state)
     updated_state, message = update_state(Einhorn::State, "einhorn", parsed[:state])
     Einhorn::State.state = updated_state
     Einhorn::Event.restore_persistent_descriptors(parsed[:persistent_descriptors])

--- a/lib/einhorn/client.rb
+++ b/lib/einhorn/client.rb
@@ -1,5 +1,6 @@
 require "set"
 require "yaml"
+require "einhorn/safe_yaml"
 
 module Einhorn
   class Client
@@ -26,7 +27,7 @@ module Einhorn
 
       def self.deserialize_message(line)
         serialized = line.gsub(/%(25|0A)/, "%25" => "%", "%0A" => "\n")
-        YAML.load(serialized)
+        SafeYAML.load(serialized)
       end
     end
 

--- a/lib/einhorn/safe_yaml.rb
+++ b/lib/einhorn/safe_yaml.rb
@@ -1,0 +1,17 @@
+require "yaml"
+
+module Einhorn
+  module SafeYAML
+    begin
+      YAML.safe_load("---", permitted_classes: [])
+    rescue ArgumentError
+      def self.load(payload)
+        YAML.safe_load(payload, [Set, Symbol, Time], [], true)
+      end
+    else
+      def self.load(payload)
+        YAML.safe_load(payload, permitted_classes: [Set, Symbol, Time], aliases: true)
+      end
+    end
+  end
+end

--- a/test/integration/_lib/helpers/einhorn_helpers.rb
+++ b/test/integration/_lib/helpers/einhorn_helpers.rb
@@ -106,7 +106,7 @@ module Helpers
 
     def get_state(client)
       client.send_command("command" => "state")
-      YAML.load(client.receive_message["message"])[:state]
+      Einhorn::SafeYAML.load(client.receive_message["message"])[:state]
     end
 
     def wait_for_open_port

--- a/test/integration/upgrading.rb
+++ b/test/integration/upgrading.rb
@@ -74,7 +74,7 @@ class UpgradeTests < EinhornIntegrationTestCase
           client.send_command("command" => "state")
           resp = client.receive_message
 
-          state = YAML.load(resp["message"])
+          state = Einhorn::SafeYAML.load(resp["message"])
           assert_equal(1, state[:state][:children].count)
 
           child = state[:state][:children].first.last

--- a/test/unit/einhorn/command/interface.rb
+++ b/test/unit/einhorn/command/interface.rb
@@ -11,7 +11,7 @@ class InterfaceTest < EinhornTestCase
       conn.expects(:write).once.with do |message|
         # Remove trailing newline
         message = message[0...-1]
-        parsed = YAML.load(CGI.unescape(message))
+        parsed = Einhorn::SafeYAML.load(CGI.unescape(message))
         parsed["message"] =~ /Welcome, gdb/
       end
       request = {


### PR DESCRIPTION
`YAML.safe_load` signature changed quite a lot between Psych 3.0 and 4.0. So to handle both we need a bit of feature testing.

I tested with both 2.5 and 3.1 locally, both passed.

cc @mperham 